### PR TITLE
Fix cycle stopping after successful record update if not using telegram notification.

### DIFF
--- a/update-cloudflare-dns.sh
+++ b/update-cloudflare-dns.sh
@@ -162,7 +162,7 @@ for record in "${dns_records[@]}"; do
 
   ### Telegram notification
   if [ ${notify_me_telegram} == "no" ]; then
-    exit 0
+    continue
   fi
 
   if [ ${notify_me_telegram} == "yes" ]; then


### PR DESCRIPTION
This should fix the issue reported in #23 .

When a record is successfully updated and telegram notifications are turned off, we should continue to the next record instead of exiting.