### PR TITLE
Fix IPv4 regexp to work in MacOS (Sequoia)

### DIFF
--- a/update-cloudflare-dns.sh
+++ b/update-cloudflare-dns.sh
@@ -51,8 +51,8 @@ if [ "${what_ip}" == "internal" ] && [ "${proxied}" == "true" ]; then
   exit 0
 fi
 
-### Valid IPv4 Regex
-REIP='^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])$'
+### Valid IPv4 octet Regex
+RX='([1-9]?[0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
 
 ### Get external ip from https://checkip.amazonaws.com
 if [ "${what_ip}" == "external" ]; then
@@ -61,7 +61,7 @@ if [ "${what_ip}" == "external" ]; then
     echo "Error! Can't get external ip from https://checkip.amazonaws.com"
     exit 0
   fi
-  if ! [[ "$ip" =~ $REIP ]]; then
+  if ! [[ "$ip" =~ ^$RX\.$RX\.$RX\.$RX$ ]]; then
     echo "Error! IP Address returned was invalid!"
     exit 0
   fi


### PR DESCRIPTION
Hello, 

Thank you for the very useful DDNS script. I encountered an issue when running the script on MacOS 15.4 Sequoia. The `$REIP` was not detecting valid IP addresses and the script execution failed to `Error! IP Address returned was invalid!` error as I reported in #33  

This PR changes the IPv4 regexp and fixes #33