### PR TITLE
Removed early loop exit if telegram updates not configured

### DIFF
--- a/update-cloudflare-dns.sh
+++ b/update-cloudflare-dns.sh
@@ -162,7 +162,7 @@ for record in "${dns_records[@]}"; do
 
   ### Telegram notification
   if [ ${notify_me_telegram} == "no" ]; then
-    exit 0
+    continue
   fi
 
   if [ ${notify_me_telegram} == "yes" ]; then


### PR DESCRIPTION
Previous logic had the script exiting after the first DNS entry if telegram updates were not configured. After changing `exit 0` to `continue` the script finishes running all DNS entries before exiting.